### PR TITLE
Updated Timesless Quiz

### DIFF
--- a/word-game/src/components/TimelessQuiz.js
+++ b/word-game/src/components/TimelessQuiz.js
@@ -72,7 +72,14 @@ export default function TimelessQuiz({theme,toggleTheme,objResponse}) {   ///rmo
         // <h1>{pokeName}</h1>    // For testing poke API
         <div  className="question-cardCont">
             {/* Header  */}
-            <h1 className="lingo">Lingo</h1>
+//             <h1 className="lingo">Lingo</h1> ---- this has been commented out to maintain the integrity of the main branch until the code beneath is agreed upon.
+            <h1 className='lingo' style={{color: "black"}}>
+              <p style={{color: "blue", display: "inline"}}>L</p>
+              <p style={{color: "green", display: "inline"}}>I</p>
+              <p style={{color: "red", display: "inline"}}>N</p>
+              <p style={{color: "yellow", display: "inline"}}>G</p>
+              <p style={{color: "white", display: "inline"}}>O:</p>
+            </h1>
             {/* <h1>{pokeName}</h1> */}
             {/* Current score  */}
             <h2 className="current-score">Current score: {score}</h2>


### PR DESCRIPTION
I have provided the styling code for the 'LINGO' within this component. The original code has been kept and commented out above the new h1 elemental change.

It is my suggestion that we find a way of duplicating the styling for 'LINGO' here so that when the screen is in light mode, the 'O' in lingo turns black in colour, and white colour when in dark mode!, This would enhance the styling and keep the text from blending into the background.